### PR TITLE
ci/cd: add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,71 @@
+---
+on:
+  push:
+    tags:
+     - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to deploy (e.g., v1.2.3)."
+        required: true
+
+name: Release
+
+# Don't run multiple releases at the same time.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  version:
+    name: Configure Version
+    outputs:
+      version: ${{ steps.output_version.outputs.version }}
+    steps:
+      - name: Validate Version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ ! "${{ github.event.inputs.version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must follow the format vX.Y.Z (e.g., v1.0.0)."
+            exit 1
+          fi
+
+          echo "Version is valid: ${{ github.event.inputs.version }}"
+
+      - name: Output Version
+        id: output_version
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            VERSION=${GITHUB_REF_NAME}
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION=${{ github.event.inputs.version }}
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "Error: Unsupported event type."
+            exit 1
+          fi
+
+  release:
+    name: Run Release
+    runs-on: ubuntu-latest
+    needs: [version]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.version.outputs.version }}
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6.1.0
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,4 @@
+---
 on:
   pull_request: {}
   push: {}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ oxide-rancher-machine-driver
 
 *.tar
 *.tar.gz
+
+dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,33 @@
+---
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    # Rancher expects the node driver binary to be in the format
+    # docker-machine-driver-*.
+    binary: docker-machine-driver-oxide
+    flags:
+      - -trimpath
+    ldflags:
+      - "-s -w -extldflags '-static -Wl,--fatal-warnings'"
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_SHA256SUMS"
+
+changelog:
+  disable: true


### PR DESCRIPTION
This patch adds a GitHub Actions workflow for running releases. It uses GoReleaser to build and release binaries.

Part of https://github.com/oxidecomputer/rancher-machine-driver-oxide/issues/9.