### PR TITLE
goreleaser: enable changelog functionality

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,3 @@ archives:
 
 checksum:
   name_template: "{{ .ProjectName }}_SHA256SUMS"
-
-changelog:
-  disable: true


### PR DESCRIPTION
This patch enables the changelog functionality of GoReleaser so that it can be used until we wire up our our changelog functionality.