### PR TITLE
readme: update custom resource annotations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ metadata:
   name: oxide
   annotations:
     privateCredentialFields: token
-    publicCredentialFields: host,project
+    publicCredentialFields: host
   finalizers:
   - controller.cattle.io/node-driver-controller
 spec:


### PR DESCRIPTION
This patch updates the annotations for the `NodeDriver` custom resource to drop the `project` field. This allows operators to use the same silo host and API token in the cloud credential while being able to specify a project at cluster creation time.