### PR TITLE
driver: update state mappings

### DIFF
--- a/oxide_test.go
+++ b/oxide_test.go
@@ -64,11 +64,11 @@ var _ = Describe("Driver", func() {
 		Entry("running", oxide.InstanceStateRunning, state.Running),
 		Entry("stopping", oxide.InstanceStateStopping, state.Stopping),
 		Entry("stopped", oxide.InstanceStateStopped, state.Stopped),
-		Entry("repairing", oxide.InstanceStateRepairing, state.Stopped),
-		Entry("rebooting", oxide.InstanceStateRebooting, state.Stopping),
+		Entry("repairing", oxide.InstanceStateRepairing, state.Starting),
+		Entry("rebooting", oxide.InstanceStateRebooting, state.Starting),
 		Entry("migrating", oxide.InstanceStateMigrating, state.Running),
 		Entry("failed", oxide.InstanceStateFailed, state.Error),
-		Entry("destroyed", oxide.InstanceStateDestroyed, state.Error),
+		Entry("destroyed", oxide.InstanceStateDestroyed, state.NotFound),
 		Entry("unknown", oxide.InstanceState("unknown"), state.None),
 	)
 })


### PR DESCRIPTION
This patch updates the mappings between an Oxide instance state to a Rancher instance state based on discussions and learnings. The semantics of the Rancher machine [state.State](https://github.com/rancher/machine/blob/99d2c8daa21d3e81eebb3cfcda46459473628126/libmachine/state/state.go#L3-L17) values are not well defined so the mappings are best effort based on reading the Rancher machine source code and other implementations.

Closes https://github.com/oxidecomputer/rancher-machine-driver-oxide/issues/5.