### PR TITLE
go: update to go v1.24.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: "go.mod"
 
       - name: Run Ginkgo
         run: go run github.com/onsi/ginkgo/v2/ginkgo -r --randomize-all --randomize-suites --race --trace --fail-on-pending --keep-going --github-output

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oxidecomputer/rancher-machine-driver-oxide
 
-go 1.23.3
+go 1.24.0
 
 replace (
 	github.com/docker/docker => github.com/moby/moby v1.4.2-0.20170731201646-1009e6a40b29


### PR DESCRIPTION
This patch updates the source code to use Go v1.24.0.