### PR TITLE
go: downgrade to go 1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oxidecomputer/rancher-machine-driver-oxide
 
-go 1.24.0
+go 1.23.6
 
 replace (
 	github.com/docker/docker => github.com/moby/moby v1.4.2-0.20170731201646-1009e6a40b29


### PR DESCRIPTION
This patch downgrades the version of Go to 1.23.6 to stay in sync with the version of Go used to build the github.com/rancher/machine module.