### PR TITLE
BREAKING CHANGE: rename flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,11 @@ test:
 .PHONY: clean
 clean:
 	rm -f $(BINDIR)/*
+
+.PHONY: lint
+lint:
+	golangci-lint run
+
+.PHONY: lint-fix
+lint-fix:
+	golangci-lint run --fix

--- a/oxide_test.go
+++ b/oxide_test.go
@@ -98,38 +98,6 @@ var _ = Describe("Driver", func() {
 			Entry("errors with invalid size unit suffix", "20 ABC,"),
 		)
 	})
-
-	Describe("ParseExternalIP", func() {
-		DescribeTable("Success",
-			func(s string, expected ExternalIP) {
-				Expect(ParseExternalIP(s)).To(Equal(expected))
-			},
-			Entry("parses ephemeral ip with ip pool id", "ephemeral,a4720b36-006b-49fc-a029-583528f18a4d", ExternalIP{
-				Type: "ephemeral", NameOrID: "a4720b36-006b-49fc-a029-583528f18a4d",
-			}),
-			Entry("parses ephemeral ip with ip pool name", "ephemeral,ip_pool_foo", ExternalIP{
-				Type: "ephemeral", NameOrID: "ip_pool_foo",
-			}),
-			Entry("parses floating ip with floating ip id", "floating,a4720b36-006b-49fc-a029-583528f18a4d", ExternalIP{
-				Type: "floating", NameOrID: "a4720b36-006b-49fc-a029-583528f18a4d",
-			}),
-			Entry("parses floating ip with floating ip name", "floating,floating_ip_foo", ExternalIP{
-				Type: "floating", NameOrID: "floating_ip_foo",
-			}),
-		)
-
-		DescribeTable("Error",
-			func(s string) {
-				_, err := ParseExternalIP(s)
-				Expect(err).To(HaveOccurred())
-			},
-			Entry("errors with empty string", ""),
-			Entry("errors with empty invalid format", ","),
-			Entry("errors with no type", ",foo"),
-			Entry("errors with no ephemeral name_or_id", "ephemeral,"),
-			Entry("errors with no floating name_or_id", "floating,"),
-		)
-	})
 })
 
 func defaultMockDriverOptions() (rv *commandstest.FakeFlagger) {


### PR DESCRIPTION
renaming flags for consistency and purpose

also restructure the ephemeral/floating IP:
* remove floating IP: it doesn't make sense in pool functionality, a FIP can only be assigned to 1 instance
* 2 flags for ephemeral: boolean flag and a pool name