### PR TITLE
goreleaser: use correct checksum template variable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,4 +31,5 @@ archives:
     name_template: "{{ .Binary }}"
 
 checksum:
-  name_template: "{{ .Binary }}_SHA256SUMS"
+  name_template: "{{ .ArtifactName }}_SHA256SUMS"
+  split: true


### PR DESCRIPTION
Updated the `checksum` attribute to use the `ArtifactName` template variable which is only accessible when `split` is `true`.