### PR TITLE
Add the ability to set local disk for additional disks on oxide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ $(BINDIR):
 
 .PHONY: test
 test:
-	$(GO) test -cover -v ./...
+	ginkgo --cover --output-dir=build  ./...
+
+.PHONY: cover
+cover: test
+	$(GO) tool cover \
+          -html=build/coverprofile.out \
+	  -o build/index.html
 
 .PHONY: clean
 clean:

--- a/additional_disk.go
+++ b/additional_disk.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dustin/go-humanize"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+type additionalDiskPart int
+
+const (
+	additionalDiskPartSizeName        = "size"
+	additionalDiskPartLabelName       = "label"
+	additionalDiskPartBackendTypeName = "type"
+)
+
+const (
+	additionalDiskPartSize additionalDiskPart = iota
+	additionalDiskPartLabel
+	additionalDiskPartBackendType
+)
+
+var additionDiskPartMap = map[string]additionalDiskPart{
+	additionalDiskPartSizeName:        additionalDiskPartSize,
+	additionalDiskPartLabelName:       additionalDiskPartLabel,
+	additionalDiskPartBackendTypeName: additionalDiskPartBackendType,
+}
+
+// additionalDisk represents a disk attached to an instance.
+type additionalDisk struct {
+	// Required. The size of the disk in bytes.
+	size uint64
+
+	// An optional label to use in the disk name for ease of identification.
+	label string
+
+	// The type of backend to use: local or distributed
+	backend oxide.DiskBackendType
+}
+
+// parseAdditionalDisk parses an `AdditionalDisk` from a string in the format
+// size=SIZE[,label=LABEL][,type=TYPE] or
+// `SIZE[[,LABEL],TYPE]` where `SIZE` is the disk size in bytes, `LABEL` is an
+// arbitrary string used within the disk name for identification, and `TYPE` is the
+// Oxide disk_backend: `local` or `distributed`. `SIZE` supports a unit suffix (e.g., 20 GiB).
+func parseAdditionalDisk(s string) (additionalDisk, error) {
+	var sizeStr string
+	label := "additional"
+	backend := oxide.DiskBackendTypeDistributed
+
+	if s == "" {
+		return additionalDisk{}, fmt.Errorf("invalid format empty string given, expected size[[,label],backend]")
+	}
+
+	fields, err := parseAdditionalDiskParts(s)
+	if err != nil {
+		return additionalDisk{}, err
+	}
+	switch len(fields) {
+	case 3:
+		if fields[2] != "" {
+			backend = oxide.DiskBackendType(fields[2])
+		}
+		fallthrough
+	case 2:
+		if fields[1] != "" {
+			label = fields[1]
+		}
+		fallthrough
+	case 1:
+		sizeStr = fields[0]
+	default:
+		return additionalDisk{}, fmt.Errorf("invalid format %q, expected size[[,label],backend]", s)
+	}
+
+	if backend != oxide.DiskBackendTypeDistributed && backend != oxide.DiskBackendTypeLocal {
+		return additionalDisk{}, fmt.Errorf("invalid backend %q, expected %q or %q", backend, oxide.DiskBackendTypeDistributed, oxide.DiskBackendTypeLocal)
+	}
+
+	size, err := humanize.ParseBytes(sizeStr)
+	if err != nil {
+		return additionalDisk{}, fmt.Errorf("failed parsing size %q %w", sizeStr, err)
+	}
+
+	a := additionalDisk{
+		size:    size,
+		label:   label,
+		backend: backend,
+	}
+
+	return a, nil
+}
+
+// return {size, label, backend}
+func parseAdditionalDiskParts(s string) (parts []string, err error) {
+	// old way
+	if !strings.Contains(s, "=") {
+		for _, part := range strings.Split(s, ",") {
+			parts = append(parts, strings.TrimSpace(part))
+		}
+		return
+	}
+
+	// new way
+	parts = make([]string, 3)
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		part := strings.Split(p, "=")
+		if len(part) != 2 {
+			err = fmt.Errorf("invalid format %q, expected \"name=value\"", p)
+			return
+		}
+		name := strings.TrimSpace(part[0])
+		value := strings.TrimSpace(part[1])
+		index, ok := additionDiskPartMap[name]
+		if !ok {
+			err = fmt.Errorf("invalid additional disk part: %q, expected %q, %q, or %q", name,
+				additionalDiskPartSizeName,
+				additionalDiskPartLabelName,
+				additionalDiskPartBackendTypeName,
+			)
+		}
+		parts[index] = value
+	}
+
+	return
+}
+
+// name returns a string representing the disk name.
+func (a *additionalDisk) name(machineName string, diskNumber int) string {
+	name := a.innerName(machineName, diskNumber)
+
+	if len(name) <= 63 {
+		return name
+	}
+
+	// the machineName is always of hte form this-is-a-long-name-<randsuffix>-<randsuffix>
+	// and we want to make sure to keep the random suffix, so that we don't have name collisions
+	toRemove := len(name) - 63
+	chunks := strings.Split(machineName, "-")
+	suffix := strings.Join(chunks[len(chunks)-2:], "-")
+	machineName = strings.Join(chunks[:len(chunks)-2], "-")
+	machineName = strings.Join([]string{
+		machineName[:len(machineName)-toRemove],
+		suffix,
+	}, "-")
+
+	return a.innerName(machineName, diskNumber)
+}
+
+// the name is disk-## because there was a bug w/ oxide where only the first 20 chars were used to distinguish disks
+// ref: https://docs.oxide.computer/guides/troubleshooting#_disk_rejected_due_to_20_char_name_match
+func (a *additionalDisk) innerName(machineName string, diskNumber int) string {
+	return fmt.Sprintf("disk-%02d-%s-%s", diskNumber, a.label, machineName)
+}
+
+func (a *additionalDisk) createInstanceDiskAttachment(i int, machineName string) oxide.InstanceDiskAttachment {
+	diskBackend := oxide.DiskBackend{
+		Value: &oxide.DiskBackendDistributed{
+			DiskSource: oxide.DiskSource{
+				Value: &oxide.DiskSourceBlank{
+					BlockSize: oxide.BlockSize(4096),
+				},
+			},
+		},
+	}
+
+	if a.backend == oxide.DiskBackendTypeLocal {
+		diskBackend = oxide.DiskBackend{
+			Value: &oxide.DiskBackendLocal{},
+		}
+	}
+
+	return oxide.InstanceDiskAttachment{
+		Value: &oxide.InstanceDiskAttachmentCreate{
+			Description: defaultDescription,
+			DiskBackend: diskBackend,
+			Name:        oxide.Name(a.name(machineName, i)),
+			Size:        oxide.ByteCount(a.size),
+		},
+	}
+}

--- a/additional_disk.go
+++ b/additional_disk.go
@@ -8,24 +8,122 @@ import (
 	"github.com/oxidecomputer/oxide.go/oxide"
 )
 
-type additionalDiskPart int
-
 const (
-	additionalDiskPartSizeName        = "size"
-	additionalDiskPartLabelName       = "label"
-	additionalDiskPartBackendTypeName = "type"
+	additionalDiskSize        = "size"
+	additionalDiskLabel       = "label"
+	additionalDiskBackendType = "type"
 )
 
-const (
-	additionalDiskPartSize additionalDiskPart = iota
-	additionalDiskPartLabel
-	additionalDiskPartBackendType
-)
+// additionalDiskParser parses a string describing an additional disk.
+type additionalDiskParser struct {
+	// additionalDisk is the final parsed and validated disk.
+	additionalDisk
 
-var additionDiskPartMap = map[string]additionalDiskPart{
-	additionalDiskPartSizeName:        additionalDiskPartSize,
-	additionalDiskPartLabelName:       additionalDiskPartLabel,
-	additionalDiskPartBackendTypeName: additionalDiskPartBackendType,
+	// sizeStr is a temporary field used to store the input string for size.
+	sizeStr string
+}
+
+// parse parses a string in the format `size=SIZE[,label=LABEL][,type=TYPE]` or
+// `SIZE[[,LABEL],TYPE]` where :
+//   - `SIZE` is the disk size in bytes. It supports a unit suffix (e.g., 20 GiB).
+//   - `LABEL` is an arbitrary string used within the disk name for identification.
+//   - `TYPE` is the Oxide `disk_backend`: `local` or `distributed`.
+func (a *additionalDiskParser) parse(s string) error {
+	if s == "" {
+		return fmt.Errorf("invalid format empty string given, expected size[[,label],backend]")
+	}
+
+	// Default values.
+	a.label = "additional"
+	a.backend = oxide.DiskBackendTypeDistributed
+
+	// Parse input string.
+	var err error
+	if !strings.Contains(s, "=") {
+		err = a.parseLegacy(s)
+	} else {
+		err = a.parseKV(s)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Parse and validate values.
+	a.size, err = humanize.ParseBytes(a.sizeStr)
+	if err != nil {
+		return fmt.Errorf("failed parsing size %q: %w", a.sizeStr, err)
+	}
+
+	if a.backend != oxide.DiskBackendTypeDistributed && a.backend != oxide.DiskBackendTypeLocal {
+		return fmt.Errorf("invalid backend %q, expected %q or %q", a.backend, oxide.DiskBackendTypeDistributed, oxide.DiskBackendTypeLocal)
+	}
+
+	return nil
+}
+
+// parseLegacy parses strings in the format `SIZE[[,LABEL],TYPE]`.
+//
+// Deprecated: This format has been deprecated in favor of the KV format and it
+// does not need to be updated to support new fields.
+func (a *additionalDiskParser) parseLegacy(s string) error {
+	fields := strings.Split(s, ",")
+	switch len(fields) {
+	case 3:
+		if s := strings.TrimSpace(fields[2]); s != "" {
+			a.backend = oxide.DiskBackendType(s)
+		}
+		fallthrough
+	case 2:
+		if s := strings.TrimSpace(fields[1]); s != "" {
+			a.label = s
+		}
+		fallthrough
+	case 1:
+		a.sizeStr = strings.TrimSpace(fields[0])
+	default:
+		return fmt.Errorf("invalid format %q, expected size[[,label],backend]", s)
+	}
+
+	return nil
+}
+
+// parseKV parses strings in the format `size=SIZE[,label=LABEL][,type=TYPE]`.
+func (a *additionalDiskParser) parseKV(s string) error {
+	for p := range strings.SplitSeq(s, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+
+		part := strings.Split(p, "=")
+		if len(part) != 2 {
+			return fmt.Errorf(`invalid format %q, expected "name=value"`, p)
+		}
+
+		name := strings.TrimSpace(part[0])
+		value := strings.TrimSpace(part[1])
+
+		switch name {
+		case additionalDiskSize:
+			a.sizeStr = value
+		case additionalDiskLabel:
+			if value != "" {
+				a.label = value
+			}
+		case additionalDiskBackendType:
+			if value != "" {
+				a.backend = oxide.DiskBackendType(value)
+			}
+		default:
+			return fmt.Errorf("invalid additional disk part: %q, expected %q, %q, or %q", name,
+				additionalDiskSize,
+				additionalDiskLabel,
+				additionalDiskBackendType,
+			)
+		}
+	}
+
+	return nil
 }
 
 // additionalDisk represents a disk attached to an instance.
@@ -38,97 +136,6 @@ type additionalDisk struct {
 
 	// The type of backend to use: local or distributed
 	backend oxide.DiskBackendType
-}
-
-// parseAdditionalDisk parses an `AdditionalDisk` from a string in the format
-// size=SIZE[,label=LABEL][,type=TYPE] or
-// `SIZE[[,LABEL],TYPE]` where `SIZE` is the disk size in bytes, `LABEL` is an
-// arbitrary string used within the disk name for identification, and `TYPE` is the
-// Oxide disk_backend: `local` or `distributed`. `SIZE` supports a unit suffix (e.g., 20 GiB).
-func parseAdditionalDisk(s string) (additionalDisk, error) {
-	var sizeStr string
-	label := "additional"
-	backend := oxide.DiskBackendTypeDistributed
-
-	if s == "" {
-		return additionalDisk{}, fmt.Errorf("invalid format empty string given, expected size[[,label],backend]")
-	}
-
-	fields, err := parseAdditionalDiskParts(s)
-	if err != nil {
-		return additionalDisk{}, err
-	}
-	switch len(fields) {
-	case 3:
-		if fields[2] != "" {
-			backend = oxide.DiskBackendType(fields[2])
-		}
-		fallthrough
-	case 2:
-		if fields[1] != "" {
-			label = fields[1]
-		}
-		fallthrough
-	case 1:
-		sizeStr = fields[0]
-	default:
-		return additionalDisk{}, fmt.Errorf("invalid format %q, expected size[[,label],backend]", s)
-	}
-
-	if backend != oxide.DiskBackendTypeDistributed && backend != oxide.DiskBackendTypeLocal {
-		return additionalDisk{}, fmt.Errorf("invalid backend %q, expected %q or %q", backend, oxide.DiskBackendTypeDistributed, oxide.DiskBackendTypeLocal)
-	}
-
-	size, err := humanize.ParseBytes(sizeStr)
-	if err != nil {
-		return additionalDisk{}, fmt.Errorf("failed parsing size %q %w", sizeStr, err)
-	}
-
-	a := additionalDisk{
-		size:    size,
-		label:   label,
-		backend: backend,
-	}
-
-	return a, nil
-}
-
-// return {size, label, backend}
-func parseAdditionalDiskParts(s string) (parts []string, err error) {
-	// old way
-	if !strings.Contains(s, "=") {
-		for _, part := range strings.Split(s, ",") {
-			parts = append(parts, strings.TrimSpace(part))
-		}
-		return
-	}
-
-	// new way
-	parts = make([]string, 3)
-	for _, p := range strings.Split(s, ",") {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		part := strings.Split(p, "=")
-		if len(part) != 2 {
-			err = fmt.Errorf("invalid format %q, expected \"name=value\"", p)
-			return
-		}
-		name := strings.TrimSpace(part[0])
-		value := strings.TrimSpace(part[1])
-		index, ok := additionDiskPartMap[name]
-		if !ok {
-			err = fmt.Errorf("invalid additional disk part: %q, expected %q, %q, or %q", name,
-				additionalDiskPartSizeName,
-				additionalDiskPartLabelName,
-				additionalDiskPartBackendTypeName,
-			)
-		}
-		parts[index] = value
-	}
-
-	return
 }
 
 // name returns a string representing the disk name.
@@ -184,4 +191,13 @@ func (a *additionalDisk) createInstanceDiskAttachment(i int, machineName string)
 			Size:        oxide.ByteCount(a.size),
 		},
 	}
+}
+
+// parseAdditionalDisk parses an `AdditionalDisk` from a string.
+func parseAdditionalDisk(s string) (additionalDisk, error) {
+	a := additionalDiskParser{}
+	if err := a.parse(s); err != nil {
+		return additionalDisk{}, err
+	}
+	return a.additionalDisk, nil
 }

--- a/additional_disk_test.go
+++ b/additional_disk_test.go
@@ -271,7 +271,7 @@ var _ = Describe("AdditionalDisks", func() {
 			Entry("errors with invalid backend", "20GiB,,backend", "invalid backend"),
 			Entry("errors with too many args", "five,is,right,out,", "invalid format"),
 			Entry("error don't mix your metaphors", "label=awesome,local", "invalid format \"local\""),
-			Entry("error no size new way", "label=awesome", "failed parsing size \"\" strconv.ParseFloat"),
+			Entry("error no size new way", "label=awesome", "failed parsing size \"\": strconv.ParseFloat"),
 			Entry("error bad key new way", "bad=good?", `invalid additional disk part: "bad", expected "size", "label", or "type"`),
 		)
 	})

--- a/additional_disk_test.go
+++ b/additional_disk_test.go
@@ -1,0 +1,278 @@
+package main
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+var _ = Describe("AdditionalDisks", func() {
+	Context("createInstanceDiskAttachment", func() {
+		It("should return a valid local disk attachment", func() {
+			aDisk := additionalDisk{
+				size:    8675309,
+				label:   "the",
+				backend: oxide.DiskBackendTypeLocal,
+			}
+
+			actual := aDisk.createInstanceDiskAttachment(1, "number")
+			attachment, ok := actual.Value.(*oxide.InstanceDiskAttachmentCreate)
+			Expect(ok).To(BeTrue())
+
+			Expect(attachment.Name).To(Equal(oxide.Name("disk-01-the-number")))
+			Expect(attachment.Size).To(Equal(oxide.ByteCount(8675309)))
+			Expect(attachment.Description).To(Equal(defaultDescription))
+
+			_, ok = attachment.DiskBackend.Value.(*oxide.DiskBackendLocal)
+			Expect(ok).To(BeTrue())
+		})
+
+		It("should return a valid distributed disk attachment", func() {
+			aDisk := additionalDisk{
+				size:    8675309,
+				label:   "the",
+				backend: oxide.DiskBackendTypeDistributed,
+			}
+
+			actual := aDisk.createInstanceDiskAttachment(1, "number")
+			attachment, ok := actual.Value.(*oxide.InstanceDiskAttachmentCreate)
+			Expect(ok).To(BeTrue())
+
+			Expect(attachment.Name).To(Equal(oxide.Name("disk-01-the-number")))
+			Expect(attachment.Size).To(Equal(oxide.ByteCount(8675309)))
+			Expect(attachment.Description).To(Equal(defaultDescription))
+
+			backend, ok := attachment.DiskBackend.Value.(*oxide.DiskBackendDistributed)
+			Expect(ok).To(BeTrue())
+
+			source, ok := backend.DiskSource.Value.(*oxide.DiskSourceBlank)
+			Expect(source.BlockSize).To(Equal(oxide.BlockSize(4096)))
+		})
+	})
+
+	Context("name", func() {
+		DescribeTable("should return a valid name (diskNumber as 1 and machineName as machine)",
+			func(expected string, aDisk additionalDisk) {
+				Expect(aDisk.name("machine", 1)).To(Equal(expected))
+			},
+			Entry("default is distributed", "disk-01-label-machine", additionalDisk{
+				label:   "label",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("local disk", "disk-01-label-machine", additionalDisk{
+				label:   "label",
+				backend: oxide.DiskBackendTypeLocal,
+			}),
+		)
+
+		It("should truncate a long named disk - intelligently - local", func() {
+			aDisk := additionalDisk{
+				size:    8675309,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeLocal,
+			}
+			Expect(aDisk.name("las01-sandbox-violet-control-plane-rqqxv-mphz5", 1)).
+				To(SatisfyAll(
+					HaveLen(63),
+					Equal("disk-01-additional-las01-sandbox-violet-control-pla-rqqxv-mphz5"),
+				))
+		})
+
+		It("should truncate a long named disk - intelligently - distributed", func() {
+			aDisk := additionalDisk{
+				size:    8675309,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}
+			Expect(aDisk.name("las01-sandbox-violet-control-plane-rqqxv-mphz5", 1)).
+				To(SatisfyAll(
+					HaveLen(63),
+					Equal("disk-01-additional-las01-sandbox-violet-control-pla-rqqxv-mphz5"),
+				))
+		})
+	})
+
+	Context("parseAdditionalDisk", func() {
+		DescribeTable("Old way",
+			func(s string, expected additionalDisk) {
+				Expect(parseAdditionalDisk(s)).To(Equal(expected))
+			},
+			Entry("parses integer without suffix", "21474836480", additionalDisk{
+				size:    21474836480,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with suffix", "10GiB", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with space suffix", "10 GiB", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer without suffix and label", "21474836480,data", additionalDisk{
+				size:    21474836480,
+				label:   "data",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with suffix and label", "10GiB,data", additionalDisk{
+				size:    10737418240,
+				label:   "data",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with space suffix and label", "10 GiB,data", additionalDisk{
+				size:    10737418240,
+				label:   "data",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer without suffix trailing comma", "21474836480,", additionalDisk{
+				size:    21474836480,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with suffix trailing comma", "10GiB,", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses valid local backend with no label", "10GiB,,local", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeLocal,
+			}),
+			Entry("parses valid distributed backend with no label", "10GiB,,distributed", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses valid local backend with awesome label", "10GiB,awesome,local", additionalDisk{
+				size:    10737418240,
+				label:   "awesome",
+				backend: oxide.DiskBackendTypeLocal,
+			}),
+			Entry("parses valid distributed backend with some label", "10GiB,some,distributed", additionalDisk{
+				size:    10737418240,
+				label:   "some",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			// extra spaces
+			Entry("parses integer with suffix trailing comma", "10GiB , ", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses valid local backend with no label", "10GiB,  ,local", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeLocal,
+			}),
+			Entry("parses valid distributed backend with no label", "10GiB  ,,  distributed", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses valid local backend with awesome label", "10GiB , awesome , local  ", additionalDisk{
+				size:    10737418240,
+				label:   "awesome",
+				backend: oxide.DiskBackendTypeLocal,
+			}),
+			Entry("parses valid distributed backend with some label", "10GiB  ,  some ,distributed  ", additionalDisk{
+				size:    10737418240,
+				label:   "some",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+		)
+
+		DescribeTable("New way",
+			func(s string, expected additionalDisk) {
+				Expect(parseAdditionalDisk(s)).To(Equal(expected))
+			},
+			Entry("parses integer without suffix", "size=21474836480", additionalDisk{
+				size:    21474836480,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with suffix", "size=10GiB", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with space suffix", "size=10 GiB", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer without suffix and label", "size=21474836480,label=data", additionalDisk{
+				size:    21474836480,
+				label:   "data",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer without suffix and label - order", "label=data,size=21474836480", additionalDisk{
+				size:    21474836480,
+				label:   "data",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with suffix and label", "size=10GiB,label=data", additionalDisk{
+				size:    10737418240,
+				label:   "data",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer and extra `,`", "size=21474836480,", additionalDisk{
+				size:    21474836480,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with suffix trailing comma", "size=10GiB", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses valid local backend with no label", "size=10GiB,type=local", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeLocal,
+			}),
+			Entry("parses valid distributed backend with no label", "size=10GiB,,type=distributed", additionalDisk{
+				size:    10737418240,
+				label:   "additional",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses valid local backend with awesome label", "size=10GiB,label=awesome,type=local", additionalDisk{
+				size:    10737418240,
+				label:   "awesome",
+				backend: oxide.DiskBackendTypeLocal,
+			}),
+			Entry("parses spaces", "type = distributed , label = some , size =  10GiB,", additionalDisk{
+				size:    10737418240,
+				label:   "some",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+			Entry("parses integer with space suffix and label - ignore extra", "size=10 GiB,label=data, ", additionalDisk{
+				size:    10737418240,
+				label:   "data",
+				backend: oxide.DiskBackendTypeDistributed,
+			}),
+		)
+
+		DescribeTable("Errors",
+			func(s string, errStr string) {
+				_, err := parseAdditionalDisk(s)
+				Expect(err).To(SatisfyAll(
+					HaveOccurred(),
+					MatchError(ContainSubstring(errStr)),
+				))
+			},
+			Entry("errors with empty string", "", "invalid format empty string given"),
+			Entry("errors with empty invalid format", ",", "failed parsing size"),
+			Entry("errors with no size", ",foo", "failed parsing size"),
+			Entry("errors with invalid size unit suffix", "20 ABC,", "failed parsing size"),
+			Entry("errors with invalid backend", "20GiB,,backend", "invalid backend"),
+			Entry("errors with too many args", "five,is,right,out,", "invalid format"),
+			Entry("error don't mix your metaphors", "label=awesome,local", "invalid format \"local\""),
+			Entry("error no size new way", "label=awesome", "failed parsing size \"\" strconv.ParseFloat"),
+			Entry("error bad key new way", "bad=good?", `invalid additional disk part: "bad", expected "size", "label", or "type"`),
+		)
+	})
+})

--- a/oxide.go
+++ b/oxide.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -107,7 +106,7 @@ type Driver struct {
 	AntiAffinityGroups []string
 
 	// Additional disks to attach to the instance.
-	AdditionalDisks []AdditionalDisk
+	additionalDisks []additionalDisk
 
 	// Custom user agent string for API requests.
 	UserAgent string
@@ -192,24 +191,9 @@ func (d *Driver) Create() error {
 		userData = b
 	}
 
-	disks := make([]oxide.InstanceDiskAttachment, len(d.AdditionalDisks))
-	for i, additionalDisk := range d.AdditionalDisks {
-		disks[i] = oxide.InstanceDiskAttachment{
-			Value: &oxide.InstanceDiskAttachmentCreate{
-				Description: defaultDescription,
-				DiskBackend: oxide.DiskBackend{
-					Value: &oxide.DiskBackendDistributed{
-						DiskSource: oxide.DiskSource{
-							Value: &oxide.DiskSourceBlank{
-								BlockSize: oxide.BlockSize(4096),
-							},
-						},
-					},
-				},
-				Name: oxide.Name(additionalDisk.Name(d.MachineName, i)),
-				Size: oxide.ByteCount(additionalDisk.Size),
-			},
-		}
+	disks := make([]oxide.InstanceDiskAttachment, len(d.additionalDisks))
+	for i, aDisk := range d.additionalDisks {
+		disks[i] = aDisk.createInstanceDiskAttachment(i, d.MachineName)
 	}
 
 	antiAffinityGroups := make([]oxide.NameOrId, 0, len(d.AntiAffinityGroups))
@@ -337,7 +321,7 @@ func (d *Driver) Create() error {
 		return fmt.Errorf("failed listing disks for instance: %w", err)
 	}
 
-	d.AdditionalDiskIDs = make([]string, 0, len(d.AdditionalDisks))
+	d.AdditionalDiskIDs = make([]string, 0, len(d.additionalDisks))
 	for _, additionalDisk := range additionalDisks {
 		// The boot disk ID state is managed irrespective of the additional disks.
 		if additionalDisk.Id == instance.BootDiskId {
@@ -403,7 +387,7 @@ func (d *Driver) GetCreateFlags() []mcnflag.Flag {
 		// Additional disks.
 		mcnflag.StringSliceFlag{
 			Name:  flagAdditionalDisk,
-			Usage: "Additional disks to attach to the instance in the format `SIZE[,LABEL]` where `SIZE` is the disk size in bytes and `LABEL` is an arbitrary string used within the disk name for identification. `SIZE` supports a unit suffix (e.g., 20 GiB).",
+			Usage: "Additional disks to attach to the instance in the format `size=SIZE[,label=LABEL][,type=TYPE]` or `SIZE[[,LABEL],BACKEND]` where `SIZE` is the disk size in bytes, `LABEL` is an arbitrary string used within the disk name for identification, and `BACKEND` is the Oxide disk_backend: `local` or `distributed`. `SIZE` supports a unit suffix (e.g., 20 GiB).",
 		},
 
 		// Networking.
@@ -684,13 +668,13 @@ func (d *Driver) SetConfigFromFlags(opts drivers.DriverOptions) error {
 		}
 		d.BootDiskSize = bootDiskSize
 
-		d.AdditionalDisks = make([]AdditionalDisk, 0)
+		d.additionalDisks = make([]additionalDisk, 0)
 		for _, diskInfo := range opts.StringSlice(flagAdditionalDisk) {
-			additionalDisk, err := ParseAdditionalDisk(diskInfo)
+			aDisk, err := parseAdditionalDisk(diskInfo)
 			if err != nil {
 				joinedParseErr = errors.Join(joinedParseErr, NewFlagParseError(flagAdditionalDisk, err))
 			}
-			d.AdditionalDisks = append(d.AdditionalDisks, additionalDisk)
+			d.additionalDisks = append(d.additionalDisks, aDisk)
 		}
 
 		if joinedParseErr != nil {
@@ -805,52 +789,4 @@ func toRancherMachineState(instanceState oxide.InstanceState) state.State {
 	default:
 		return state.None
 	}
-}
-
-// AdditionalDisk represents a disk attached to an instance.
-type AdditionalDisk struct {
-	// Required. The size of the disk in bytes.
-	Size uint64
-
-	// An optional label to use in the disk name for ease of identification.
-	Label string
-}
-
-// ParseAdditionalDisk parses an `AdditionalDisk` from a string in the format
-// `SIZE[,LABEL]` where `SIZE` is the disk size in bytes and `LABEL` is an
-// arbitrary string used within the disk name for identification. `SIZE`
-// supports a unit suffix (e.g., 20 GiB).
-func ParseAdditionalDisk(s string) (AdditionalDisk, error) {
-	var sizeStr string
-	label := "additional"
-
-	fields := strings.Split(s, ",")
-	switch len(fields) {
-	case 2:
-		sizeStr = fields[0]
-		if fields[1] != "" {
-			label = fields[1]
-		}
-	case 1:
-		sizeStr = fields[0]
-	default:
-		return AdditionalDisk{}, fmt.Errorf("invalid format %q, expected size[,label]", s)
-	}
-
-	size, err := humanize.ParseBytes(sizeStr)
-	if err != nil {
-		return AdditionalDisk{}, fmt.Errorf("failed parsing size %q %w", sizeStr, err)
-	}
-
-	a := AdditionalDisk{
-		Size:  size,
-		Label: label,
-	}
-
-	return a, nil
-}
-
-// Name returns a string representing the disk name.
-func (a AdditionalDisk) Name(machineName string, diskNumber int) string {
-	return fmt.Sprintf("disk-%02d-%s-%s", diskNumber, a.Label, machineName)
 }

--- a/oxide_test.go
+++ b/oxide_test.go
@@ -71,33 +71,6 @@ var _ = Describe("Driver", func() {
 		Entry("destroyed", oxide.InstanceStateDestroyed, state.NotFound),
 		Entry("unknown", oxide.InstanceState("unknown"), state.None),
 	)
-
-	Describe("ParseAdditionalDisk", func() {
-		DescribeTable("Success",
-			func(s string, expected AdditionalDisk) {
-				Expect(ParseAdditionalDisk(s)).To(Equal(expected))
-			},
-			Entry("parses integer without suffix", "21474836480", AdditionalDisk{Size: 21474836480, Label: "additional"}),
-			Entry("parses integer with suffix", "10GiB", AdditionalDisk{Size: 10737418240, Label: "additional"}),
-			Entry("parses integer with space suffix", "10 GiB", AdditionalDisk{Size: 10737418240, Label: "additional"}),
-			Entry("parses integer without suffix and label", "21474836480,data", AdditionalDisk{Size: 21474836480, Label: "data"}),
-			Entry("parses integer with suffix and label", "10GiB,data", AdditionalDisk{Size: 10737418240, Label: "data"}),
-			Entry("parses integer with space suffix and label", "10 GiB,data", AdditionalDisk{Size: 10737418240, Label: "data"}),
-			Entry("parses integer without suffix trailing comma", "21474836480,", AdditionalDisk{Size: 21474836480, Label: "additional"}),
-			Entry("parses integer with suffix trailing comma", "10GiB,", AdditionalDisk{Size: 10737418240, Label: "additional"}),
-		)
-
-		DescribeTable("Error",
-			func(s string) {
-				_, err := ParseAdditionalDisk(s)
-				Expect(err).To(HaveOccurred())
-			},
-			Entry("errors with empty string", ""),
-			Entry("errors with empty invalid format", ","),
-			Entry("errors with no size", ",foo"),
-			Entry("errors with invalid size unit suffix", "20 ABC,"),
-		)
-	})
 })
 
 func defaultMockDriverOptions() (rv *commandstest.FakeFlagger) {


### PR DESCRIPTION
Additional Disks can be added VMs created as Rancher nodes with the node driver.

Currently, they take a string arguement of `SIZE[,LABEL]`, this change adds another optional part of the string `BACKEND`

New usage info:
```
Additional disks to attach to the instance in the format `SIZE[[,LABEL],BACKEND]` where `SIZE` is the disk size in bytes, `LABEL` is an arbitrary string used within the disk name for identification, and `BACKEND` is the Oxide disk_backend: `local` or `distributed`. `SIZE` supports a unit suffix (e.g., 20 GiB).
```