### PR TITLE
test: implement end-to-end test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,76 @@
+---
+on:
+  workflow_dispatch:
+    inputs:
+      node_driver_url:
+        description: "URL to the docker-machine-driver-oxide binary to test."
+        default: "https://github.com/oxidecomputer/rancher-machine-driver-oxide/releases/download/v0.11.0/docker-machine-driver-oxide"
+        required: false
+        type: string
+      node_driver_checksum:
+        description: "SHA256 checksum of the node driver binary."
+        default: "d0fd21a622b90fb2f2c9d99e70036bdbf8eceb75072ee506ff8fb784e1178b09"
+        required: false
+        type: string
+
+name: End-to-End Test
+
+# Only allow one workflow execution at a time as it provisions real Oxide
+# infrastructure that does not guarantee to be free of name conflicts.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: Rancher Node Driver
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      RANCHER_E2E: "1"
+      RANCHER_E2E_SHOWCASE_DIR: ${{ github.workspace }}/showcase/integration/rancher
+      RANCHER_E2E_STAGE_RKE2_OXIDE_PROFILE: e2e
+      RANCHER_E2E_STAGE_RKE2_TF_VAR_project: sse
+      RANCHER_E2E_STAGE_RKE2_TF_VAR_source_image_id: 55bcf752-595e-425d-9923-817f82b0d5b8 # suse-linux-micro-2026-06-22-232354
+      RANCHER_E2E_STAGE_RKE2_TF_VAR_floating_ip_pool_id: 4a125719-9d1d-49e9-a2e4-042053a4716b # public
+      RANCHER_E2E_STAGE_RANCHER_TF_VAR_rancher_password: ${{ secrets.RANCHER_PASSWORD }}
+      RANCHER_E2E_STAGE_NODEDRIVER_TF_VAR_oxide_profile: e2e
+      RANCHER_E2E_STAGE_K8S_TF_VAR_ccm_oxide_profile: e2e
+      RANCHER_E2E_STAGE_NODEDRIVER_TF_VAR_oxide_nodedriver_url: ${{ inputs.node_driver_url }}
+      RANCHER_E2E_STAGE_NODEDRIVER_TF_VAR_oxide_nodedriver_checksum: ${{ inputs.node_driver_checksum }}
+    steps:
+      - name: Checkout Rancher Node Driver
+        uses: actions/checkout@v7
+
+      - name: Checkout Showcase
+        uses: actions/checkout@v7
+        with:
+          repository: oxidecomputer/showcase
+          path: showcase
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
+      - name: Configure Oxide Credentials
+        env:
+          OXIDE_HOST: ${{ secrets.OXIDE_HOST }}
+          OXIDE_TOKEN: ${{ secrets.OXIDE_TOKEN }}
+        run: |
+          mkdir -p "$HOME/.config/oxide"
+          cat > "$HOME/.config/oxide/credentials.toml" <<EOF
+          [profile.e2e]
+          host = "$OXIDE_HOST"
+          token = "$OXIDE_TOKEN"
+          EOF
+          chmod 600 "$HOME/.config/oxide/credentials.toml"
+
+      - name: Run End-to-End Test
+        run: |
+          go test -run TestRancherNodeDriver -v -timeout 60m .

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1,0 +1,125 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	// applyAttempts is the number of times a stage's `terraform apply` is
+	// attempted before giving up.
+	applyAttempts = 3
+
+	// applyRetryDelay is how long to wait between apply attempts.
+	applyRetryDelay = 1 * time.Minute
+)
+
+// terraformStages are the Terraform configurations under
+// `oxidecomputer/showcase/integration/rancher`, in dependency order. The
+// `image` stage is intentionally excluded because it is Packer, not Terraform.
+var terraformStages = []string{
+	"rke2",
+	"rancher",
+	"nodedriver",
+	"k8s",
+	"longhorn",
+}
+
+func TestRancherNodeDriver(t *testing.T) {
+	if os.Getenv("RANCHER_E2E") == "" {
+		t.Skip("set RANCHER_E2E=1 to run the Rancher end-to-end test")
+	}
+
+	rancherDir := os.Getenv("RANCHER_E2E_SHOWCASE_DIR")
+	if rancherDir == "" {
+		t.Fatal("RANCHER_E2E_SHOWCASE_DIR must point at the cloned oxidecomputer/showcase/integration/rancher repository")
+	}
+	if _, err := os.Stat(rancherDir); err != nil {
+		t.Fatalf("RANCHER_E2E_SHOWCASE_DIR %q: %v", rancherDir, err)
+	}
+
+	terraformBin := os.Getenv("RANCHER_E2E_TERRAFORM_BIN")
+	if terraformBin == "" {
+		terraformBin = "terraform"
+	}
+	if _, err := exec.LookPath(terraformBin); err != nil {
+		t.Fatalf("terraform binary %q not found: %v", terraformBin, err)
+	}
+
+	for _, stage := range terraformStages {
+		stageDir := filepath.Join(rancherDir, stage)
+
+		extraEnv := stageEnv(stage)
+
+		t.Cleanup(func() {
+			if err := terraform(t, terraformBin, stageDir, extraEnv,
+				"destroy", "-input=false", "-auto-approve"); err != nil {
+				t.Errorf("stage %q destroy: %v", stage, err)
+			}
+		})
+
+		ok := t.Run(stage, func(t *testing.T) {
+			if err := terraform(t, terraformBin, stageDir, extraEnv, "init", "-input=false"); err != nil {
+				t.Fatalf("init: %v", err)
+			}
+
+			var err error
+			for attempt := 1; attempt <= applyAttempts; attempt++ {
+				err = terraform(t, terraformBin, stageDir, extraEnv,
+					"apply", "-input=false", "-auto-approve")
+				if err == nil {
+					break
+				}
+				if attempt < applyAttempts {
+					t.Logf("apply attempt %d/%d failed: %v; retrying in %s",
+						attempt, applyAttempts, err, time.Duration(attempt)*applyRetryDelay)
+					time.Sleep(time.Duration(attempt) * applyRetryDelay)
+				}
+			}
+			if err != nil {
+				t.Fatalf("apply failed after %d attempts: %v", applyAttempts, err)
+			}
+		})
+		if !ok {
+			t.Fatalf("stage %q failed; halting pipeline", stage)
+		}
+	}
+}
+
+func terraform(t *testing.T, terraformBin string, dir string, extraEnv []string, args ...string) error {
+	t.Helper()
+
+	cmd := exec.Command(terraformBin, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"TF_IN_AUTOMATION=1",
+		"TF_INPUT=0",
+	)
+	cmd.Env = append(cmd.Env, extraEnv...)
+
+	cmd.Stdout = t.Output()
+	cmd.Stderr = t.Output()
+
+	t.Logf("terraform %v (in %s)", args, dir)
+	return cmd.Run()
+}
+
+func stageEnv(stage string) []string {
+	prefix := "RANCHER_E2E_STAGE_" + strings.ToUpper(stage) + "_"
+
+	var env []string
+	for _, kv := range os.Environ() {
+		if name, ok := strings.CutPrefix(kv, prefix); ok {
+			env = append(env, name)
+		}
+	}
+	return env
+}


### PR DESCRIPTION
Created an end-to-end test that exercises the Rancher configuration from https://github.com/oxidecomputer/showcase along with a corresponding GitHub Actions workflow.

Resolves SSE-329.