### PR TITLE
fix: make remove idempotent

### DIFF
--- a/oxide.go
+++ b/oxide.go
@@ -525,15 +525,19 @@ func (d *Driver) Remove() error {
 		d.oxideClient = client
 	}
 
+	instanceExists := true
 	if err := d.Stop(); err != nil {
-		return err
+		if !errors.Is(err, oxide.ErrHTTP404) {
+			return err
+		}
+		instanceExists = false
 	}
 
 	// The instance cannot be deleted until it's stopped. Wait for it to stop.
 	stopCtx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
 	defer cancel()
 
-	for {
+	for instanceExists {
 		select {
 		case <-stopCtx.Done():
 			return fmt.Errorf("timed out waiting for instance to stop: %w", stopCtx.Err())
@@ -542,6 +546,9 @@ func (d *Driver) Remove() error {
 
 		currentState, err := d.GetState()
 		if err != nil {
+			if errors.Is(err, oxide.ErrHTTP404) {
+				break
+			}
 			return err
 		}
 
@@ -552,26 +559,26 @@ func (d *Driver) Remove() error {
 
 	if err := d.oxideClient.CurrentUserSshKeyDelete(context.TODO(), oxide.CurrentUserSshKeyDeleteParams{
 		SshKey: oxide.NameOrId(d.SSHPublicKeyID),
-	}); err != nil {
+	}); err != nil && !errors.Is(err, oxide.ErrHTTP404) {
 		return err
 	}
 
 	if err := d.oxideClient.InstanceDelete(context.TODO(), oxide.InstanceDeleteParams{
 		Instance: oxide.NameOrId(d.InstanceID),
-	}); err != nil {
+	}); err != nil && !errors.Is(err, oxide.ErrHTTP404) {
 		return err
 	}
 
 	if err := d.oxideClient.DiskDelete(context.TODO(), oxide.DiskDeleteParams{
 		Disk: oxide.NameOrId(d.BootDiskID),
-	}); err != nil {
+	}); err != nil && !errors.Is(err, oxide.ErrHTTP404) {
 		return err
 	}
 
 	for _, additionalDiskID := range d.AdditionalDiskIDs {
 		if err := d.oxideClient.DiskDelete(context.TODO(), oxide.DiskDeleteParams{
 			Disk: oxide.NameOrId(additionalDiskID),
-		}); err != nil {
+		}); err != nil && !errors.Is(err, oxide.ErrHTTP404) {
 			return err
 		}
 	}

--- a/oxide_test.go
+++ b/oxide_test.go
@@ -6,6 +6,9 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/oxidecomputer/oxide.go/oxide"
@@ -52,6 +55,89 @@ var _ = Describe("Driver", func() {
 				Expect(err.Error()).To(ContainSubstring("required option \"oxide-project\" not set"))
 				Expect(err.Error()).To(ContainSubstring("required option \"oxide-boot-disk-image-id\" not set"))
 			})
+		})
+	})
+
+	Describe("Remove", func() {
+		It("should finish removing resources after a partial failure", func() {
+			sshKeyExists := true
+			instanceExists := true
+			bootDiskExists := true
+			additionalDiskExists := true
+			failInstanceDelete := true
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/instances/instance-id/stop":
+					if !instanceExists {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					_, _ = w.Write([]byte("{}"))
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/instance-id":
+					if !instanceExists {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					_, _ = w.Write([]byte(`{"run_state":"stopped"}`))
+				case r.Method == http.MethodDelete && r.URL.Path == "/v1/me/ssh-keys/ssh-key-id":
+					if !sshKeyExists {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					sshKeyExists = false
+					w.WriteHeader(http.StatusNoContent)
+				case r.Method == http.MethodDelete && r.URL.Path == "/v1/instances/instance-id":
+					if failInstanceDelete {
+						failInstanceDelete = false
+						http.Error(w, "failed deleting instance", http.StatusInternalServerError)
+						return
+					}
+					if !instanceExists {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					instanceExists = false
+					w.WriteHeader(http.StatusNoContent)
+				case r.Method == http.MethodDelete && r.URL.Path == "/v1/disks/boot-disk-id":
+					if !bootDiskExists {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					bootDiskExists = false
+					w.WriteHeader(http.StatusNoContent)
+				case r.Method == http.MethodDelete && r.URL.Path == "/v1/disks/additional-disk-id":
+					if !additionalDiskExists {
+						http.Error(w, "not found", http.StatusNotFound)
+						return
+					}
+					additionalDiskExists = false
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			SUT.Host = server.URL
+			SUT.Token = "token"
+			SUT.SSHPublicKeyID = "ssh-key-id"
+			SUT.InstanceID = "instance-id"
+			SUT.BootDiskID = "boot-disk-id"
+			SUT.AdditionalDiskIDs = []string{"additional-disk-id"}
+
+			Expect(SUT.Remove()).To(HaveOccurred())
+			Expect(sshKeyExists).To(BeFalse())
+			Expect(instanceExists).To(BeTrue())
+			Expect(bootDiskExists).To(BeTrue())
+			Expect(additionalDiskExists).To(BeTrue())
+
+			Expect(SUT.Remove()).To(Succeed())
+			Expect(instanceExists).To(BeFalse())
+			Expect(bootDiskExists).To(BeFalse())
+			Expect(additionalDiskExists).To(BeFalse())
+
+			Expect(SUT.Remove()).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
Updated `Remove` to be idempotent to prevent leaking resources.

Resolves [SSE-416](https://linear.app/oxide/issue/SSE-416).