### PR TITLE
fix: cleanup resources orphaned during create

### DIFF
--- a/oxide.go
+++ b/oxide.go
@@ -29,6 +29,9 @@ const (
 	defaultDescription  = "Managed by the Oxide Rancher machine driver."
 	defaultMemory       = "4 GiB"
 	defaultBootDiskSize = "20 GiB"
+	retryAttempts       = 3
+	retryDelay          = time.Second
+	stopTimeout         = 2 * time.Minute
 )
 
 const (
@@ -159,7 +162,7 @@ func (d *Driver) createOxideClient() (*oxide.Client, error) {
 // disks) and updates the machine driver with state for use by other methods.
 // Create must start the instance otherwise the machine driver will time out
 // waiting for the instance to start.
-func (d *Driver) Create() error {
+func (d *Driver) Create() (err error) {
 	if d.oxideClient == nil {
 		client, err := d.createOxideClient()
 		if err != nil {
@@ -167,6 +170,20 @@ func (d *Driver) Create() error {
 		}
 		d.oxideClient = client
 	}
+
+	// Defer the cleanup of created resources if [Create] errors so we don't leak
+	// any resources.
+	defer func() {
+		if err == nil {
+			return
+		}
+		if removeErr := d.Remove(); removeErr != nil {
+			err = errors.Join(err, fmt.Errorf(
+				"failed removing resources after create failure: %w",
+				removeErr,
+			))
+		}
+	}()
 
 	pubKey, err := d.createSSHKeyPair()
 	if err != nil {
@@ -278,6 +295,7 @@ func (d *Driver) Create() error {
 			UserData:      base64.StdEncoding.EncodeToString(userData),
 		},
 	}
+
 	instance, err := d.oxideClient.InstanceCreate(context.TODO(), icp)
 	if err != nil {
 		return err
@@ -285,6 +303,16 @@ func (d *Driver) Create() error {
 
 	d.InstanceID = instance.Id
 	d.BootDiskID = instance.BootDiskId
+	d.AdditionalDiskIDs = nil
+
+	if len(d.additionalDisks) > 0 {
+		err := retry(context.TODO(), func() error {
+			return d.recordAdditionalDiskIDs(context.TODO())
+		}, retryAttempts, retryDelay)
+		if err != nil {
+			return fmt.Errorf("failed listing disks for instance: %w", err)
+		}
+	}
 
 	inilp := oxide.InstanceNetworkInterfaceListParams{
 		Instance: oxide.NameOrId(d.InstanceID),
@@ -314,20 +342,45 @@ func (d *Driver) Create() error {
 		)
 	}
 
-	additionalDisks, err := d.oxideClient.InstanceDiskListAllPages(context.TODO(), oxide.InstanceDiskListParams{
+	return nil
+}
+
+func (d *Driver) recordAdditionalDiskIDs(ctx context.Context) error {
+	disks, err := d.oxideClient.InstanceDiskListAllPages(ctx, oxide.InstanceDiskListParams{
 		Instance: oxide.NameOrId(d.InstanceID),
 	})
 	if err != nil {
-		return fmt.Errorf("failed listing disks for instance: %w", err)
+		return err
 	}
 
-	d.AdditionalDiskIDs = make([]string, 0, len(d.additionalDisks))
-	for _, additionalDisk := range additionalDisks {
+	recorded := make(map[string]struct{}, len(d.AdditionalDiskIDs))
+	for _, diskID := range d.AdditionalDiskIDs {
+		recorded[diskID] = struct{}{}
+	}
+	expected := make(map[string]struct{}, len(d.additionalDisks))
+	for i, disk := range d.additionalDisks {
+		expected[disk.name(d.MachineName, i)] = struct{}{}
+	}
+	for _, disk := range disks {
 		// The boot disk ID state is managed irrespective of the additional disks.
-		if additionalDisk.Id == instance.BootDiskId {
+		if disk.Id == d.BootDiskID {
 			continue
 		}
-		d.AdditionalDiskIDs = append(d.AdditionalDiskIDs, additionalDisk.Id)
+		if _, ok := expected[string(disk.Name)]; !ok {
+			continue
+		}
+		if _, ok := recorded[disk.Id]; ok {
+			continue
+		}
+		d.AdditionalDiskIDs = append(d.AdditionalDiskIDs, disk.Id)
+		recorded[disk.Id] = struct{}{}
+	}
+	if len(d.AdditionalDiskIDs) != len(d.additionalDisks) {
+		return fmt.Errorf(
+			"found %d of %d additional disks",
+			len(d.AdditionalDiskIDs),
+			len(d.additionalDisks),
+		)
 	}
 
 	return nil
@@ -525,65 +578,139 @@ func (d *Driver) Remove() error {
 		d.oxideClient = client
 	}
 
-	instanceExists := true
-	if err := d.Stop(); err != nil {
-		if !errors.Is(err, oxide.ErrHTTP404) {
-			return err
+	var removeErr error
+	// Retain failures encountered while preparing the instance for deletion.
+	// They only matter if deleting the instance also fails.
+	var instanceReadinessErr error
+	instanceExists := d.InstanceID != ""
+	stopCtx, cancel := context.WithTimeout(context.TODO(), stopTimeout)
+	defer cancel()
+
+	if instanceExists && len(d.AdditionalDiskIDs) < len(d.additionalDisks) {
+		err := retry(stopCtx, func() error {
+			return d.recordAdditionalDiskIDs(stopCtx)
+		}, retryAttempts, retryDelay)
+		if errors.Is(err, oxide.ErrHTTP404) {
+			instanceExists = false
+		} else if err != nil {
+			return fmt.Errorf("failed recording additional disks: %w", err)
 		}
-		instanceExists = false
+	}
+
+	if instanceExists {
+		instanceReadinessErr = retry(stopCtx, func() error {
+			_, err := d.oxideClient.InstanceStop(stopCtx, oxide.InstanceStopParams{
+				Instance: oxide.NameOrId(d.InstanceID),
+			})
+			return err
+		}, retryAttempts, retryDelay)
+		if errors.Is(instanceReadinessErr, oxide.ErrHTTP404) {
+			instanceExists = false
+			instanceReadinessErr = nil
+		}
 	}
 
 	// The instance cannot be deleted until it's stopped. Wait for it to stop.
-	stopCtx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
-	defer cancel()
-
 	for instanceExists {
-		select {
-		case <-stopCtx.Done():
-			return fmt.Errorf("timed out waiting for instance to stop: %w", stopCtx.Err())
-		default:
-		}
-
-		currentState, err := d.GetState()
+		instance, err := d.oxideClient.InstanceView(stopCtx, oxide.InstanceViewParams{
+			Instance: oxide.NameOrId(d.InstanceID),
+		})
 		if err != nil {
 			if errors.Is(err, oxide.ErrHTTP404) {
+				instanceReadinessErr = nil
 				break
 			}
-			return err
+			if !isTransientError(err) {
+				instanceReadinessErr = errors.Join(
+					instanceReadinessErr,
+					fmt.Errorf("failed getting instance state: %w", err),
+				)
+				break
+			}
+		} else {
+			currentState := toRancherMachineState(instance.RunState)
+			if currentState == state.Stopped || currentState == state.NotFound {
+				instanceReadinessErr = nil
+				break
+			}
 		}
 
-		if currentState == state.Stopped {
-			break
+		select {
+		case <-stopCtx.Done():
+			instanceReadinessErr = errors.Join(
+				instanceReadinessErr,
+				fmt.Errorf(
+					"timed out waiting for instance to stop: %w",
+					stopCtx.Err(),
+				),
+			)
+			instanceExists = false
+		case <-time.After(retryDelay):
 		}
 	}
 
-	if err := d.oxideClient.CurrentUserSshKeyDelete(context.TODO(), oxide.CurrentUserSshKeyDeleteParams{
-		SshKey: oxide.NameOrId(d.SSHPublicKeyID),
-	}); err != nil && !errors.Is(err, oxide.ErrHTTP404) {
-		return err
+	if d.SSHPublicKeyID != "" {
+		err := retry(context.TODO(), func() error {
+			return d.oxideClient.CurrentUserSshKeyDelete(
+				context.TODO(),
+				oxide.CurrentUserSshKeyDeleteParams{
+					SshKey: oxide.NameOrId(d.SSHPublicKeyID),
+				},
+			)
+		}, retryAttempts, retryDelay)
+		if err != nil && !errors.Is(err, oxide.ErrHTTP404) {
+			removeErr = errors.Join(removeErr, fmt.Errorf(
+				"failed deleting SSH key: %w",
+				err,
+			))
+		}
 	}
 
-	if err := d.oxideClient.InstanceDelete(context.TODO(), oxide.InstanceDeleteParams{
-		Instance: oxide.NameOrId(d.InstanceID),
-	}); err != nil && !errors.Is(err, oxide.ErrHTTP404) {
-		return err
+	if d.InstanceID != "" {
+		err := retry(context.TODO(), func() error {
+			return d.oxideClient.InstanceDelete(context.TODO(), oxide.InstanceDeleteParams{
+				Instance: oxide.NameOrId(d.InstanceID),
+			})
+		}, retryAttempts, retryDelay)
+		if err != nil && !errors.Is(err, oxide.ErrHTTP404) {
+			removeErr = errors.Join(
+				removeErr,
+				instanceReadinessErr,
+				fmt.Errorf("failed deleting instance: %w", err),
+			)
+		}
 	}
 
-	if err := d.oxideClient.DiskDelete(context.TODO(), oxide.DiskDeleteParams{
-		Disk: oxide.NameOrId(d.BootDiskID),
-	}); err != nil && !errors.Is(err, oxide.ErrHTTP404) {
-		return err
+	if d.BootDiskID != "" {
+		err := retry(context.TODO(), func() error {
+			return d.oxideClient.DiskDelete(context.TODO(), oxide.DiskDeleteParams{
+				Disk: oxide.NameOrId(d.BootDiskID),
+			})
+		}, retryAttempts, retryDelay)
+		if err != nil && !errors.Is(err, oxide.ErrHTTP404) {
+			removeErr = errors.Join(removeErr, fmt.Errorf(
+				"failed deleting boot disk: %w",
+				err,
+			))
+		}
 	}
 
 	for _, additionalDiskID := range d.AdditionalDiskIDs {
-		if err := d.oxideClient.DiskDelete(context.TODO(), oxide.DiskDeleteParams{
-			Disk: oxide.NameOrId(additionalDiskID),
-		}); err != nil && !errors.Is(err, oxide.ErrHTTP404) {
-			return err
+		err := retry(context.TODO(), func() error {
+			return d.oxideClient.DiskDelete(context.TODO(), oxide.DiskDeleteParams{
+				Disk: oxide.NameOrId(additionalDiskID),
+			})
+		}, retryAttempts, retryDelay)
+		if err != nil && !errors.Is(err, oxide.ErrHTTP404) {
+			removeErr = errors.Join(removeErr, fmt.Errorf(
+				"failed deleting additional disk %q: %w",
+				additionalDiskID,
+				err,
+			))
 		}
 	}
 
-	return nil
+	return removeErr
 }
 
 // Restart restarts the instance without changing its configuration.
@@ -796,4 +923,41 @@ func toRancherMachineState(instanceState oxide.InstanceState) state.State {
 	default:
 		return state.None
 	}
+}
+
+func retry(
+	ctx context.Context,
+	fn func() error,
+	attempts int,
+	delay time.Duration,
+) error {
+	var err error
+	for attempt := range attempts {
+		err = fn()
+		if err == nil || errors.Is(err, oxide.ErrHTTP404) {
+			return err
+		}
+		if !isTransientError(err) {
+			return err
+		}
+		if attempt < attempts-1 {
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+	return err
+}
+
+func isTransientError(err error) bool {
+	var httpErr *oxide.HTTPError
+	if !errors.As(err, &httpErr) {
+		return true
+	}
+	status := httpErr.HTTPResponse.StatusCode
+	return status == 409 || status == 429 || status >= 500
 }

--- a/oxide_test.go
+++ b/oxide_test.go
@@ -6,8 +6,10 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,12 +61,12 @@ var _ = Describe("Driver", func() {
 	})
 
 	Describe("Remove", func() {
-		It("should finish removing resources after a partial failure", func() {
+		It("should retry removal after a transient failure", func() {
 			sshKeyExists := true
 			instanceExists := true
 			bootDiskExists := true
 			additionalDiskExists := true
-			failInstanceDelete := true
+			instanceDeleteAttempts := 0
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				switch {
@@ -88,8 +90,8 @@ var _ = Describe("Driver", func() {
 					sshKeyExists = false
 					w.WriteHeader(http.StatusNoContent)
 				case r.Method == http.MethodDelete && r.URL.Path == "/v1/instances/instance-id":
-					if failInstanceDelete {
-						failInstanceDelete = false
+					instanceDeleteAttempts++
+					if instanceDeleteAttempts == 1 {
 						http.Error(w, "failed deleting instance", http.StatusInternalServerError)
 						return
 					}
@@ -126,18 +128,238 @@ var _ = Describe("Driver", func() {
 			SUT.BootDiskID = "boot-disk-id"
 			SUT.AdditionalDiskIDs = []string{"additional-disk-id"}
 
-			Expect(SUT.Remove()).To(HaveOccurred())
-			Expect(sshKeyExists).To(BeFalse())
-			Expect(instanceExists).To(BeTrue())
-			Expect(bootDiskExists).To(BeTrue())
-			Expect(additionalDiskExists).To(BeTrue())
-
 			Expect(SUT.Remove()).To(Succeed())
+			Expect(sshKeyExists).To(BeFalse())
 			Expect(instanceExists).To(BeFalse())
 			Expect(bootDiskExists).To(BeFalse())
 			Expect(additionalDiskExists).To(BeFalse())
+			Expect(instanceDeleteAttempts).To(Equal(2))
 
 			Expect(SUT.Remove()).To(Succeed())
+		})
+
+		It("should keep polling after transient stop and state failures", func() {
+			stopAttempts := 0
+			stateAttempts := 0
+			instanceDeleted := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/instances/instance-id/stop":
+					stopAttempts++
+					http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/instance-id":
+					stateAttempts++
+					if stateAttempts <= retryAttempts+1 {
+						http.Error(w, "temporarily unavailable", http.StatusServiceUnavailable)
+						return
+					}
+					_, _ = w.Write([]byte(`{"run_state":"stopped"}`))
+				case r.Method == http.MethodDelete && r.URL.Path == "/v1/instances/instance-id":
+					instanceDeleted = true
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			SUT.Host = server.URL
+			SUT.Token = "token"
+			SUT.InstanceID = "instance-id"
+
+			Expect(SUT.Remove()).To(Succeed())
+			Expect(stopAttempts).To(Equal(retryAttempts))
+			Expect(stateAttempts).To(Equal(retryAttempts + 2))
+			Expect(instanceDeleted).To(BeTrue())
+		})
+
+		It("should attempt every resource after permanent deletion failures", func() {
+			deleteRequests := make(map[string]int)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/instances/instance-id/stop":
+					_, _ = w.Write([]byte("{}"))
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/instance-id":
+					_, _ = w.Write([]byte(`{"run_state":"stopped"}`))
+				case r.Method == http.MethodDelete:
+					deleteRequests[r.URL.Path]++
+					http.Error(w, "invalid request", http.StatusBadRequest)
+				default:
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			SUT.Host = server.URL
+			SUT.Token = "token"
+			SUT.SSHPublicKeyID = "ssh-key-id"
+			SUT.InstanceID = "instance-id"
+			SUT.BootDiskID = "boot-disk-id"
+			SUT.AdditionalDiskIDs = []string{"additional-disk-id"}
+
+			err := SUT.Remove()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed deleting SSH key"))
+			Expect(err.Error()).To(ContainSubstring("failed deleting instance"))
+			Expect(err.Error()).To(ContainSubstring("failed deleting boot disk"))
+			Expect(err.Error()).To(ContainSubstring("failed deleting additional disk"))
+			Expect(deleteRequests).To(HaveLen(4))
+			for _, requests := range deleteRequests {
+				Expect(requests).To(Equal(1))
+			}
+		})
+
+		It("should recover missing additional disk IDs before deletion", func() {
+			additionalDiskDeleted := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/instance-id/disks":
+					_, _ = w.Write([]byte(`{"items":[{"id":"additional-disk-id","name":"disk-00-data-bob"}]}`))
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/instances/instance-id/stop":
+					_, _ = w.Write([]byte("{}"))
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/instance-id":
+					_, _ = w.Write([]byte(`{"run_state":"stopped"}`))
+				case r.Method == http.MethodDelete && r.URL.Path == "/v1/instances/instance-id":
+					w.WriteHeader(http.StatusNoContent)
+				case r.Method == http.MethodDelete && r.URL.Path == "/v1/disks/additional-disk-id":
+					additionalDiskDeleted = true
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			SUT.Host = server.URL
+			SUT.Token = "token"
+			SUT.InstanceID = "instance-id"
+			SUT.additionalDisks = []additionalDisk{{label: "data"}}
+
+			Expect(SUT.Remove()).To(Succeed())
+			Expect(SUT.AdditionalDiskIDs).To(Equal([]string{"additional-disk-id"}))
+			Expect(additionalDiskDeleted).To(BeTrue())
+		})
+
+		It("should preserve the instance when disk ID recovery fails", func() {
+			stopCalled := false
+			instanceDeleteCalled := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/instance-id/disks":
+					http.Error(w, "invalid request", http.StatusBadRequest)
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/instances/instance-id/stop":
+					stopCalled = true
+					_, _ = w.Write([]byte("{}"))
+				case r.Method == http.MethodDelete && r.URL.Path == "/v1/instances/instance-id":
+					instanceDeleteCalled = true
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+				}
+			}))
+			defer server.Close()
+
+			SUT.Host = server.URL
+			SUT.Token = "token"
+			SUT.InstanceID = "instance-id"
+			SUT.additionalDisks = []additionalDisk{{label: "data"}}
+
+			err := SUT.Remove()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed recording additional disks"))
+			Expect(stopCalled).To(BeFalse())
+			Expect(instanceDeleteCalled).To(BeFalse())
+		})
+
+		It("should bound retries with the provided context", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+			defer cancel()
+			attempts := 0
+			start := time.Now()
+			err := retry(ctx, func() error {
+				attempts++
+				<-ctx.Done()
+				return ctx.Err()
+			}, retryAttempts, time.Second)
+			Expect(err).To(MatchError(context.DeadlineExceeded))
+			Expect(time.Since(start)).To(BeNumerically("<", time.Second))
+			Expect(attempts).To(Equal(1))
+		})
+
+	})
+
+	Describe("recordAdditionalDiskIDs", func() {
+		It("should record every disk except the boot disk", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				Expect(r.Method).To(Equal(http.MethodGet))
+				Expect(r.URL.Path).To(Equal("/v1/instances/instance-id/disks"))
+				_, _ = w.Write([]byte(`{"items":[{"id":"boot-disk-id"},{"id":"additional-disk-id","name":"disk-00-data-bob"},{"id":"unrelated-disk-id","name":"unrelated"}]}`))
+			}))
+			defer server.Close()
+
+			SUT.Host = server.URL
+			SUT.Token = "token"
+			SUT.InstanceID = "instance-id"
+			SUT.BootDiskID = "boot-disk-id"
+			SUT.additionalDisks = []additionalDisk{{label: "data"}}
+			client, err := SUT.createOxideClient()
+			Expect(err).NotTo(HaveOccurred())
+			SUT.oxideClient = client
+
+			Expect(SUT.recordAdditionalDiskIDs(context.Background())).To(Succeed())
+			Expect(SUT.AdditionalDiskIDs).To(Equal([]string{"additional-disk-id"}))
+		})
+
+		It("should fail when not every configured disk is listed", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"items":[{"id":"boot-disk-id"}]}`))
+			}))
+			defer server.Close()
+
+			SUT.Host = server.URL
+			SUT.Token = "token"
+			SUT.InstanceID = "instance-id"
+			SUT.BootDiskID = "boot-disk-id"
+			SUT.additionalDisks = []additionalDisk{{}}
+			client, err := SUT.createOxideClient()
+			Expect(err).NotTo(HaveOccurred())
+			SUT.oxideClient = client
+
+			err = SUT.recordAdditionalDiskIDs(context.Background())
+			Expect(err).To(MatchError("found 0 of 1 additional disks"))
+		})
+
+		It("should retain disk IDs across incomplete listings", func() {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests++
+				if requests == 1 {
+					_, _ = w.Write([]byte(`{"items":[{"id":"additional-disk-1","name":"disk-00-one-bob"}]}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"items":[{"id":"additional-disk-2","name":"disk-01-two-bob"}]}`))
+			}))
+			defer server.Close()
+
+			SUT.Host = server.URL
+			SUT.Token = "token"
+			SUT.InstanceID = "instance-id"
+			SUT.BootDiskID = "boot-disk-id"
+			SUT.additionalDisks = []additionalDisk{
+				{label: "one"},
+				{label: "two"},
+			}
+			client, err := SUT.createOxideClient()
+			Expect(err).NotTo(HaveOccurred())
+			SUT.oxideClient = client
+
+			Expect(retry(context.Background(), func() error {
+				return SUT.recordAdditionalDiskIDs(context.Background())
+			}, retryAttempts, time.Millisecond)).To(Succeed())
+			Expect(SUT.AdditionalDiskIDs).To(ConsistOf(
+				"additional-disk-1",
+				"additional-disk-2",
+			))
 		})
 	})
 


### PR DESCRIPTION
Made the following changes:

* The `Create` method now defers cleanup after failures.
* The `Remove` method now retries deletion for resources.

Resolves SSE-159.